### PR TITLE
Updated test workflow to use pip and added numba patch script.

### DIFF
--- a/.github/workflows/patch.sh
+++ b/.github/workflows/patch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Patch numba
+s=$(python -c 'import numba; print(numba.__path__[0])')
+s+='/core/types/scalars.py'
+
+line=$(grep -n 'class Boolean(Hashable):' $s | cut -f1 -d:)
+
+head -n $line $s > tmp-scalars.py
+cat >> tmp-scalars.py << EOF
+    def __init__(self, name):
+        super(Boolean, self).__init__(name)
+        self.bitwidth = 8
+EOF
+
+length=$(wc -l < $s)
+let "length -= line"
+tail -n $length $s >> tmp-scalars.py
+
+mv tmp-scalars.py $s
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,13 @@ jobs:
         ls
     - name: Install dependencies
       run: |
-        ./install.sh
+        sudo apt-get install libopenmpi-dev
+        pip install numpy numba h5py matplotlib scipy pytest colorama mpi4py
+        pip list 
+        pip install -e .
+    - name: Patch numba
+      run : |
+        bash .github/workflows/patch.sh
     - name: Run Unit Tests
       run: |
         pytest


### PR DESCRIPTION
In the build, Install dependencies and Patch numba succeed. All 20 unit tests pass, seemingly gets hung up on 
`cd tests/regression`
`python run.py`
and I don't know why!